### PR TITLE
ユーザー新規登録画面にプログレスバー追加 ＋ α実装

### DIFF
--- a/app/assets/stylesheets/devise/registrations/create_address.scss
+++ b/app/assets/stylesheets/devise/registrations/create_address.scss
@@ -1,3 +1,79 @@
+.regi-header3 {
+  height: 115px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  &_image {
+    width: 170px;
+  }
+  &_progress {
+    width: 270px;
+    margin-left: 80px;
+    &_text {
+      display: flex;
+      padding-left: 10px;
+      font-size: 13px;
+      color: #888;
+      &_first {
+        color: red;
+      }
+      &_second {
+        padding-left: 38px;
+        color: red;
+      }
+      &_complete {
+        padding-left: 62px;
+        font-weight: bold;
+        color: red;
+      }
+    }
+    &_bar {
+      display: flex;
+      justify-content: center;
+      margin-top: 13px;
+      margin-left: 32px;
+      z-index: -1;
+      &_left {
+        width: 100px;
+        height: 2px;
+        background: red;
+      }
+      &_right {
+        width: 95px;
+        height: 2px;
+        background: red;
+      }
+    }
+    @mixin circle {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+    }
+    &_circle {
+      display: flex;
+      justify-content: space-between;
+      margin: -7px auto 0;
+      padding-left: 41px;
+      padding-right: 10px;
+      &_first {
+        @include circle;
+        z-index: 2;
+        background-color: red;
+      }
+      &_second {
+        @include circle;
+        z-index: 2;
+        background-color: red;
+      }
+      &_complete {
+        @include circle;
+        z-index: 2;
+        background-color: red;
+      }
+    }
+  }
+}
+
 .create-account {
   background-color: white;
   margin: 0 auto 40px;

--- a/app/assets/stylesheets/devise/registrations/new.scss
+++ b/app/assets/stylesheets/devise/registrations/new.scss
@@ -1,3 +1,77 @@
+.regi-header1 {
+  height: 115px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  &_image {
+    width: 170px;
+  }
+  &_progress {
+    width: 270px;
+    margin-left: 80px;
+    &_text {
+      display: flex;
+      padding-left: 10px;
+      font-size: 13px;
+      color: #888;
+      &_first {
+        font-weight: bold;
+        color: red;
+      }
+      &_second {
+        padding-left: 38px;
+      }
+      &_complete {
+        padding-left: 62px;
+      }
+    }
+    &_bar {
+      display: flex;
+      justify-content: center;
+      margin-top: 13px;
+      margin-left: 32px;
+      z-index: -1;
+      &_left {
+        width: 100px;
+        height: 2px;
+        background: rgb(180, 180, 180);
+      }
+      &_right {
+        width: 95px;
+        height: 2px;
+        background: rgb(180, 180, 180);
+      }
+    }
+    @mixin circle {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+    }
+    &_circle {
+      display: flex;
+      justify-content: space-between;
+      margin: -7px auto 0;
+      padding-left: 41px;
+      padding-right: 10px;
+      &_first {
+        @include circle;
+        z-index: 2;
+        background-color: #ea352d;
+      }
+      &_second {
+        @include circle;
+        z-index: 2;
+        background-color: rgb(180, 180, 180);
+      }
+      &_complete {
+        @include circle;
+        z-index: 2;
+        background-color: rgb(180, 180, 180);
+      }
+    }
+  }
+}
+
 .registration {
   background-color: white;
   margin: 0 auto 40px;

--- a/app/assets/stylesheets/devise/registrations/new_address.scss
+++ b/app/assets/stylesheets/devise/registrations/new_address.scss
@@ -1,3 +1,79 @@
+.regi-header2 {
+  height: 115px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  &_image {
+    width: 170px;
+  }
+  &_progress {
+    width: 270px;
+    margin-left: 80px;
+    &_text {
+      display: flex;
+      padding-left: 10px;
+      font-size: 13px;
+      color: #888;
+      &_first {
+        color: red;
+      }
+      &_second {
+        padding-left: 38px;
+        font-weight: bold;
+        color: red;
+      }
+      &_complete {
+        padding-left: 62px;
+        color: rgb(180, 180, 180);
+      }
+    }
+    &_bar {
+      display: flex;
+      justify-content: center;
+      margin-top: 13px;
+      margin-left: 32px;
+      z-index: -1;
+      &_left {
+        width: 100px;
+        height: 2px;
+        background: red;
+      }
+      &_right {
+        width: 95px;
+        height: 2px;
+        background: rgb(180, 180, 180);
+      }
+    }
+    @mixin circle {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+    }
+    &_circle {
+      display: flex;
+      justify-content: space-between;
+      margin: -7px auto 0;
+      padding-left: 41px;
+      padding-right: 10px;
+      &_first {
+        @include circle;
+        z-index: 2;
+        background-color: red;
+      }
+      &_second {
+        @include circle;
+        z-index: 2;
+        background-color: red;
+      }
+      &_complete {
+        @include circle;
+        z-index: 2;
+        background-color: rgb(180, 180, 180);
+      }
+    }
+  }
+}
+
 .registration {
   background-color: white;
   margin: 0 auto 40px;

--- a/app/assets/stylesheets/devise/sessions/new.scss
+++ b/app/assets/stylesheets/devise/sessions/new.scss
@@ -13,12 +13,12 @@
     padding: 40px 0 40px;
     border-bottom: solid 2px whitesmoke;
     &_btn {
-      height: 43px;
-      width: 350px;
-      padding: 11px;
-      background-color: #3CCACE;
-      margin: 0 auto;
-      margin-top: 7px;
+      margin-top: 20px;
+      .new-registration {
+        padding: 15px 135px;
+        background-color: #3CCACE;
+        margin-top: 20px;
+      }
     }
     a {
       text-decoration: none;
@@ -48,6 +48,7 @@
         }
       }
     }
+
     .action {
       text-decoration: none;
       color: white;

--- a/app/assets/stylesheets/users/show.scss
+++ b/app/assets/stylesheets/users/show.scss
@@ -23,8 +23,11 @@
     }
     &_name {
       font-size: 14px;
+      font-weight: bold;
+      text-align: center;
     }
     &_item-length {
+      text-align: center;
       font-size: 14px;
     }
   }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
 
   def show
+    @nickname = current_user.nickname
   end
   
 end

--- a/app/views/devise/registrations/create_address.html.haml
+++ b/app/views/devise/registrations/create_address.html.haml
@@ -1,4 +1,22 @@
-= render 'share/top-icon'
+.regi-header3
+  .regi-header3_image
+    = link_to root_path do
+      = image_tag 'logo/logo.png', width: '100%'
+  .regi-header3_progress
+    .regi-header3_progress_text
+      .regi-header3_progress_text_first
+        = "会員情報入力"
+      .regi-header3_progress_text_second
+        = "住所登録"
+      .regi-header3_progress_text_complete
+        = "完了"
+    .regi-header3_progress_bar
+      .regi-header3_progress_bar_left
+      .regi-header3_progress_bar_right
+    .regi-header3_progress_circle
+      .regi-header3_progress_circle_first
+      .regi-header3_progress_circle_second
+      .regi-header3_progress_circle_complete
 
 .create-account
   %h2 登録が完了しました

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,4 +1,22 @@
-= render 'share/top-icon'
+.regi-header1
+  .regi-header1_image
+    = link_to root_path do
+      = image_tag 'logo/logo.png', width: '100%'
+  .regi-header1_progress
+    .regi-header1_progress_text
+      .regi-header1_progress_text_first
+        = "会員情報入力"
+      .regi-header1_progress_text_second
+        = "住所登録"
+      .regi-header1_progress_text_complete
+        = "完了"
+    .regi-header1_progress_bar
+      .regi-header1_progress_bar_left
+      .regi-header1_progress_bar_right
+    .regi-header1_progress_circle
+      .regi-header1_progress_circle_first
+      .regi-header1_progress_circle_second
+      .regi-header1_progress_circle_complete
 
 .registration
   .registration_title

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -1,4 +1,22 @@
-= render 'share/top-icon'
+.regi-header2
+  .regi-header2_image
+    = link_to root_path do
+      = image_tag 'logo/logo.png', width: '100%'
+  .regi-header2_progress
+    .regi-header2_progress_text
+      .regi-header2_progress_text_first
+        = "会員情報入力"
+      .regi-header2_progress_text_second
+        = "住所登録"
+      .regi-header2_progress_text_complete
+        = "完了"
+    .regi-header2_progress_bar
+      .regi-header2_progress_bar_left
+      .regi-header2_progress_bar_right
+    .regi-header2_progress_circle
+      .regi-header2_progress_circle_first
+      .regi-header2_progress_circle_second
+      .regi-header2_progress_circle_complete
 
 .registration
   .registration_title

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -7,7 +7,7 @@
     %h2 アカウントをお持ちでない方はこちら
     .sign-in_new_btn
       - if devise_mapping.registerable? && controller_name != 'registrations'
-        = link_to "新規会員登録", new_registration_path(resource_name)
+        = link_to "新規会員登録", new_registration_path(resource_name), class: "new-registration"
 
   .sign-in_input
     .sign-in_input_content

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -11,7 +11,7 @@
       .mypage_profile_icon
         = image_tag "icon/member_photo_noimage_thumb.png", width: "100%"
         .mypage_profile_name
-          = "ユーザー１"
+          = @nickname
         .mypage_profile_item-length
           = "出品数 5"
     .news-content


### PR DESCRIPTION
# what
以下を追加実装
・ユーザー新規登録画面にプログレスバー追加
・マイページにログイン中のユーザーニックネームを表示
※ログイン画面の新規登録ボタンがマウスオーバーするように修正

# why
・ユーザーとのインタラクションを充実させるため