### PR TITLE
ER図の更新＋マイページの不要なマウスオーバー削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # DB設計
 
 ## ER図
-![image](https://user-images.githubusercontent.com/53987306/78009231-abe05980-737b-11ea-8d23-a8f3262d5570.png)
+![image](https://user-images.githubusercontent.com/61734650/79534565-de958c00-80b5-11ea-966f-e175661c6bf3.png)
 
 ## usersテーブル
 |Column|Type|Options|

--- a/app/assets/stylesheets/share/_side.scss
+++ b/app/assets/stylesheets/share/_side.scss
@@ -4,7 +4,6 @@
   &_list {
     list-style: none;
     text-decoration: none;
-    cursor: pointer;
   }
   &_list-item {
     position: relative;
@@ -17,6 +16,19 @@
     color: #333;
     padding-left: 20px;
     margin:  0 10px 2px 10px;
+  }
+  &_list-item-link {
+    position: relative;
+    display: block;
+    justify-content: center;
+    height: 55px;
+    line-height: 55px;
+    background: #fff;
+    font-size: 14px;
+    color: #333;
+    padding-left: 20px;
+    margin:  0 10px 2px 10px;
+    cursor: pointer;
     &:hover {
       background-color: #eee;
     }

--- a/app/assets/stylesheets/users/show.scss
+++ b/app/assets/stylesheets/users/show.scss
@@ -56,9 +56,6 @@
       width: 40px;
       height: 40px;
     }
-    &:hover {
-      background-color: #eee;
-    }
     i2 {
       float: right;
       position: absolute;

--- a/app/views/share/_side.html.haml
+++ b/app/views/share/_side.html.haml
@@ -1,61 +1,58 @@
 %nav.side-bar
   %ul.side-bar_list
-    %li.side-bar_list-item
+    %li.side-bar_list-item-link
       = link_to "マイページ", user_path
       %i.fa.fa-chevron-right
     %li.side-bar_list-item
-      = link_to "出品する", "#"
+      = "下書き一覧"
       %i.fa.fa-chevron-right
     %li.side-bar_list-item
-      = link_to "下書き一覧", "#"
+      = "出品した商品 - 出品中"
       %i.fa.fa-chevron-right
     %li.side-bar_list-item
-      = link_to "出品した商品 - 出品中", "#"
+      = "出品した商品 - 取引中"
       %i.fa.fa-chevron-right
     %li.side-bar_list-item
-      = link_to "出品した商品 - 取引中", "#"
+      = "出品した商品 - 売却済み"
       %i.fa.fa-chevron-right
     %li.side-bar_list-item
-      = link_to "出品した商品 - 売却済み", "#"
+      = " 購入した商品 - 取引中"
       %i.fa.fa-chevron-right
     %li.side-bar_list-item
-      = link_to " 購入した商品 - 取引中", "#"
+      = "購入した商品 - 過去の取引"
       %i.fa.fa-chevron-right
     %li.side-bar_list-item
-      = link_to "購入した商品 - 過去の取引", "#"
+      = "ニュース一覧"
       %i.fa.fa-chevron-right
     %li.side-bar_list-item
-      = link_to "ニュース一覧", "#"
+      = "ガイド"
       %i.fa.fa-chevron-right
     %li.side-bar_list-item
-      = link_to "ガイド", "#"
-      %i.fa.fa-chevron-right
-    %li.side-bar_list-item
-      = link_to " お問い合わせ", "#"
+      = " お問い合わせ"
       %i.fa.fa-chevron-right
 
   %h1.side-nav-head 設定
   %ul.side-bar_list
     %li.side-bar_list-item
-      = link_to "プロフィール", "#"
+      = "プロフィール"
       %i.fa.fa-chevron-right
     %li.side-bar_list-item
-      = link_to "発送元・お届け先住所変更", "#"
+      = "発送元・お届け先住所変更"
       %i.fa.fa-chevron-right
     %li.side-bar_list-item
-      = link_to "支払い方法", "#"
+      = "支払い方法"
       %i.fa.fa-chevron-right
     %li.side-bar_list-item
-      = link_to "メール/パスワード", "#"
+      = "メール/パスワード"
       %i.fa.fa-chevron-right
     %li.side-bar_list-item
-      = link_to "本人情報", "#"
+      = "本人情報"
       %i.fa.fa-chevron-right
     = link_to card_user_path do
-      %li.side-bar_list-item
+      %li.side-bar_list-item-link
         = "クレジットカード登録"
         %i.fa.fa-chevron-right
     = link_to logout_user_path do
-      %li.side-bar_list-item
+      %li.side-bar_list-item-link
         = "ログアウト"
         %i.fa.fa-chevron-right


### PR DESCRIPTION
# what
・ER図を最新の使用に更新
・マイページでリンク先が無いボタンのマウスオーバーを外した

# why
・DB設計の最新情報を共有するため
・機能しないボタン押下による誤操作を防ぐため