### PR TITLE
マイページの表示崩れを修正＋アイコン再設定

### DIFF
--- a/app/assets/stylesheets/users/responsive.scss
+++ b/app/assets/stylesheets/users/responsive.scss
@@ -21,6 +21,9 @@
       &_list-item {
         margin: 0 0 2px;
       }
+      &_list-item-link {
+        margin: 0 0 2px;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/users/show.scss
+++ b/app/assets/stylesheets/users/show.scss
@@ -59,8 +59,11 @@
     display: flex;
     position: relative;
     .logo-image {
-      width: 40px;
-      height: 40px;
+      width: 32px;
+      height: 35px;
+      position: absolute;
+      top: 25px;
+      left: 25px;
     }
     i2 {
       float: right;
@@ -70,7 +73,7 @@
     }
     &_text {
       font-size: 14px;
-      padding: 0 20px;
+      padding-left: 75px;
       line-height: 85px;
       word-wrap: break-word;
     }

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -17,22 +17,27 @@
           = current_user.items.length
     .news-content
       .news-content_message
-        .news-content_message_text  
+        = image_tag "logo.png", class: 'logo-image'
+        .news-content_message_text
           事務局から個別メッセージ「ログイン通知」
           %i2.fa.fa-chevron-right
       .news-content_message
+        = image_tag "logo.png", class: 'logo-image'
         .news-content_message_text
           まとめて出品して１万名にP3,000が当たる！
         %i2.fa.fa-chevron-right
       .news-content_message
+        = image_tag "logo.png", class: 'logo-image'
         .news-content_message_text
           明日、5%還元クーポンの有効期限が切れます！
         %i2.fa.fa-chevron-right
       .news-content_message
+        = image_tag "logo.png", class: 'logo-image'
         .news-content_message_text
           最大P1,000がもらえるキャンペーン開催中！
         %i2.fa.fa-chevron-right
       .news-content_message
+        = image_tag "logo.png", class: 'logo-image'
         .news-content_message_text
           ポイントがもらえるキャンペーン開催中！
         %i2.fa.fa-chevron-right


### PR DESCRIPTION
# what
マイページのCSS崩れを修正
・レスポンシブ対応時のサイドバー幅のずれを修正
・お知らせ欄の文頭にアイコン表示を復帰

# why
表示の整合性を保つため